### PR TITLE
Support extendedflow

### DIFF
--- a/bin/asstatd.pl
+++ b/bin/asstatd.pl
@@ -517,9 +517,6 @@ sub parse_sflow {
 			next;
 		}
 		
-		my $snmpin = $sFlowSample->{'inputInterface'};
-		my $snmpout = $sFlowSample->{'outputInterface'};
-		
 		if ($snmpin >= 1073741823 || $snmpout >= 1073741823) {
 			# invalid interface index - could be dropped packet or internal
 			# (routing protocol, management etc.)

--- a/bin/asstatd.pl
+++ b/bin/asstatd.pl
@@ -503,8 +503,19 @@ sub parse_sflow {
 		# only process standard structures
 		next if ($sFlowSample->{'sampleTypeEnterprise'} != 0);
 		
-		# only process normal flow samples
-		next if ($sFlowSample->{'sampleTypeFormat'} != 1);
+		my $snmpin;
+		my $snmpout;
+		if ($sFlowSample->{'sampleTypeFormat'} == 1) {
+			$snmpin = $sFlowSample->{'inputInterface'};
+			$snmpout = $sFlowSample->{'outputInterface'};
+		} elsif ($sFlowSample->{'sampleTypeFormat'} == 3) {
+			next if $sFlowSample->{'inputInterfaceFormat'} != 0;
+			next if $sFlowSample->{'outputInterfaceFormat'} != 0;
+			$snmpin = $sFlowSample->{inputInterfaceValue};
+			$snmpout = $sFlowSample->{outputInterfaceValue};
+		} else {
+			next;
+		}
 		
 		my $snmpin = $sFlowSample->{'inputInterface'};
 		my $snmpout = $sFlowSample->{'outputInterface'};


### PR DESCRIPTION
Support extendedflow (entreprise = 0, format = 3)
In that case, when inputInterfaceFormat and outputInterfaceFormat is 0, inputInterfaceValue and outputInterfaceValue contains the ifIndex

See http://sflow.org/SFLOW-DATAGRAM5.txt for details

Signed-off-by: jack <jack@k-net.pro>