### PR TITLE
generate-asinfo.py: get country code from last field

### DIFF
--- a/contrib/generate-asinfo.py
+++ b/contrib/generate-asinfo.py
@@ -9,6 +9,11 @@ for line in sys.stdin:
 	except ValueError:
 		continue
 
+	try:
+		data,country = data.rsplit(',',1)
+	except:
+		data = data
+
 	if data == '-Private Use AS-':
 		data = 'Private Use AS'
 


### PR DESCRIPTION
The country code from the last field is more accurate. 
Example: AS 1836, CC field 'EU' and data field 'CH'