### PR TITLE
Add THREADS env var to control number of threads

### DIFF
--- a/bin/rrd-extractstats.pl
+++ b/bin/rrd-extractstats.pl
@@ -43,7 +43,7 @@ $|=1;
 my $i :shared = 0;
 
 my $num_workers	= 1;
-if (($ENV{'THREADS'} =~ /^\d+$/) and ($ENV{'THREADS'} > 0)) { 
+if (($ENV{'THREADS'}) and ($ENV{'THREADS'} =~ /^\d+$/) and ($ENV{'THREADS'} > 0)) { 
     $num_workers = $ENV{'THREADS'};
 }
 print("Using " . $num_workers . " threads.\n");

--- a/bin/rrd-extractstats.pl
+++ b/bin/rrd-extractstats.pl
@@ -42,8 +42,7 @@ my @rrdfiles = File::Find::Rule->maxdepth(2)->file->in($rrdpath);
 $|=1;
 my $i :shared = 0;
 
-my $cpus = do { local @ARGV='/proc/cpuinfo'; grep /^processor\s+:/, <>;};
-my $num_workers	= $cpus / 2;
+my $num_workers	= 1;
 if (($ENV{'THREADS'} =~ /^\d+$/) and ($ENV{'THREADS'} > 0)) { 
     $num_workers = $ENV{'THREADS'};
 }

--- a/bin/rrd-extractstats.pl
+++ b/bin/rrd-extractstats.pl
@@ -44,6 +44,11 @@ my $i :shared = 0;
 
 my $cpus = do { local @ARGV='/proc/cpuinfo'; grep /^processor\s+:/, <>;};
 my $num_workers	= $cpus / 2;
+if (($ENV{'THREADS'} =~ /^\d+$/) and ($ENV{'THREADS'} > 0)) { 
+    $num_workers = $ENV{'THREADS'};
+}
+print("Using " . $num_workers . " threads.\n");
+
 my $num_work_units = scalar @rrdfiles;
 
 my $q = Thread::Queue->new();


### PR DESCRIPTION
Added a THREADS env var because the default thread count (cpu cores / 2) seems to be contraproductive on one of my servers. With 48 total cores and running `rrd-extractstats.pl` on 24 of them the process runs twice as longer than with 8 cores only.

I'm not sure of the reason yet and I use 8 cores on this server after some experiments.

Also with too many busy cores server load was too high. I'm not sure if it is related but in this case I also got some errors from `asstatsd.pl` like the one below.

```
Error updating RRD file /data/as-stats/rrd/f4/60148.rrd: could not lock RRD
```

Usage example with the env var:
```
$ THREADS=8 /root/AS-Stats/bin/rrd-extractstats.pl /data/as-stats/rrd /data/as-stats/conf/knownlinks /data/as-stats/asstats_day.txt
```