### PR TITLE
contrib/generate-asinfo.py: Correcting syntax errors

### DIFF
--- a/contrib/generate-asinfo.py
+++ b/contrib/generate-asinfo.py
@@ -31,4 +31,4 @@ for line in sys.stdin:
     if name.startswith('- '):
         name = name[2:]
 
-    print("%s\t%s\t%s\t%s" % (asn,macro,name,country))
+    print("%s\t%s\t%s,%s\t%s" % (asn,macro,name,country,country))

--- a/contrib/generate-asinfo.py
+++ b/contrib/generate-asinfo.py
@@ -27,7 +27,7 @@ for line in sys.stdin:
 		macro = 'UNSPECIFIED'
 		name = data
 
- 	if name.startswith('- '):
+	if name.startswith('- '):
 		name = name[2:]
 
-	print "%s\t%s\t%s\t%s" % (asn,macro,name,country)
+	print("%s\t%s\t%s\t%s" % (asn,macro,name,country))

--- a/contrib/generate-asinfo.py
+++ b/contrib/generate-asinfo.py
@@ -4,30 +4,31 @@
 import sys
 
 for line in sys.stdin:
-	try:
-		asn,country,_,_,data = [_.strip() for _ in line.split('|')]
-	except ValueError:
-		continue
+    try:
+        asn,country,_,_,data = [_.strip() for _ in line.split('|')]
+    except ValueError:
+        continue
 
-	try:
-		data,country = data.rsplit(',',1)
-	except:
-		data = data
+    try:
+        data,country = data.rsplit(',',1)
+        country = country.strip()
+    except:
+        data = data
 
-	if data == '-Private Use AS-':
-		data = 'Private Use AS'
+    if data == '-Private Use AS-':
+        data = 'Private Use AS'
 
-	try:
-		macro,name = data.split(' ',1)
-	except:
-		macro = data
-		name = data
+    try:
+        macro,name = data.split(' ',1)
+    except:
+        macro = data
+        name = data
 
-	if not (macro.count('-') or macro.upper() == macro or name.startswith('- ')) or macro == 'UK':
-		macro = 'UNSPECIFIED'
-		name = data
+    if not (macro.count('-') or macro.upper() == macro or name.startswith('- ')) or macro == 'UK':
+        macro = 'UNSPECIFIED'
+        name = data
 
-	if name.startswith('- '):
-		name = name[2:]
+    if name.startswith('- '):
+        name = name[2:]
 
-	print("%s\t%s\t%s\t%s" % (asn,macro,name,country))
+    print("%s\t%s\t%s\t%s" % (asn,macro,name,country))


### PR DESCRIPTION
```pytb
alarig@jeunet ~ % (echo begin; echo verbose; for i in `seq 1 65535`; do echo "AS$i"; done; echo end) | nc whois.cymru.com 43 | ./generate-asinfo.py > asinfo.txt
  File "./generate-asinfo.py", line 30
    if name.startswith('- '):
                            ^
TabError: inconsistent use of tabs and spaces in indentation
zsh: done       ( echo begin; echo verbose; for i in `seq 1 65535`; do; echo "AS$i"; done;  ;  | nc whois.cymru.com 43 |
zsh: exit 1     ./generate-asinfo.py > asinfo.txt
```
```pytb
alarig@jeunet ~ % (echo begin; echo verbose; for i in `seq 1 65535`; do echo "AS$i"; done; echo end) | nc whois.cymru.com 43 | ./generate-asinfo.py > asinfo.txt
  File "./generate-asinfo.py", line 33
    print "%s\t%s\t%s\t%s" % (asn,macro,name,country)
          ^
SyntaxError: invalid syntax
zsh: done       ( echo begin; echo verbose; for i in `seq 1 65535`; do; echo "AS$i"; done;  ;  | nc whois.cymru.com 43 |
zsh: exit 1     ./generate-asinfo.py > asinfo.txt
```