### PR TITLE
rrd-extractstats.pl: fix bareword (disallowed by use strict, fixes #91)

### DIFF
--- a/bin/rrd-extractstats.pl
+++ b/bin/rrd-extractstats.pl
@@ -54,7 +54,7 @@ try {
 	my $sth = $db->prepare("SELECT asn, checked_at FROM stats") or die('field missing');
 	$sth->execute();
 	while(my($item, $data) = $sth->fetchrow_array()) {
-		as_list->{$item} = $data;
+		$as_list->{$item} = $data;
 	}
 
 	$db_version = 2;


### PR DESCRIPTION
Correct a small bareword error in rrd-extractstats.pl that makes it abort on recent perl versions due to `use strict;`