### PR TITLE
Fix syntax error

### DIFF
--- a/bin/asstatd.pl
+++ b/bin/asstatd.pl
@@ -380,11 +380,11 @@ sub parse_netflow_v9_data_flowset {
 		if (defined($snmpin) && defined($snmpout)) {
                         if (not (defined($srcas))) { $srcas=0; }
                         if (not (defined($dstas))) { $dstas=0; }
-			if defined($srcip) {
+			if (defined($srcip)) {
 				$srcas = replace_asn($srcip, $srcas);
 			}
 
-			if defined($dstip) {
+			if (defined($dstip)) {
 				$dstas = replace_asn($dstip, $dstas);
 			}
 


### PR DESCRIPTION
Previous PR #99 merged into master is broken due to a syntax error:

	# /opt/as-stats/bin/asstatd.pl -r /opt/as-stats/data/rrd -k /opt/as-stats/conf/knownlinks -P 0 -p 9000 -a 12345 -n -m
	syntax error at /opt/as-stats/bin/asstatd.pl line 383, near "if defined"
	syntax error at /opt/as-stats/bin/asstatd.pl line 387, near "if defined"
	...
	/opt/as-stats/bin/asstatd.pl has too many errors.